### PR TITLE
feat: redirect authenticated users to app.curiabots.com

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,15 @@ server {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self';" always;
 
+    # Redirect authenticated users to the app.
+    # The _oauth2_proxy cookie is set on .curiabots.com by oauth2-proxy,
+    # so it is sent to curiabots.com as well. If present, the user has
+    # (or recently had) an active session — redirect them to the app
+    # where oauth2-proxy will validate the session properly.
+    if ($cookie__oauth2_proxy) {
+        return 302 https://app.curiabots.com;
+    }
+
     # SSG — serve pre-built static files (no SPA fallback needed)
     location / {
         try_files $uri $uri/ $uri/index.html =404;


### PR DESCRIPTION
## Summary

- Detect the `_oauth2_proxy` cookie in nginx and redirect to `https://app.curiabots.com` when present
- Anonymous visitors continue to see the landing page normally

## How it works

The `_oauth2_proxy` cookie is set by oauth2-proxy on the `.curiabots.com` domain, which means it is sent to `curiabots.com` and `www.curiabots.com` as well. When nginx detects this cookie, it returns a `302` redirect to the app.

| Visitor | Cookie | Result |
|---|---|---|
| Anonymous | None | Landing page (200) |
| Authenticated | Valid `_oauth2_proxy` | 302 → `app.curiabots.com` → Dashboard |
| Expired session | Stale `_oauth2_proxy` | 302 → `app.curiabots.com` → oauth2-proxy re-authenticates transparently |

## Notes

- **SEO safe**: Crawlers don't carry `_oauth2_proxy` cookies, so they always see the landing page
- The `if` directive at `server` level with a simple `return` is a [documented safe use](https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/) in nginx
- Security headers are included in the redirect response
- No JavaScript or external API calls needed — pure server-side detection

## Testing

```bash
# Without cookie → 200
curl -sI https://curiabots.com

# With cookie → 302 to app.curiabots.com
curl -sI -b "_oauth2_proxy=test" https://curiabots.com
```

Verified locally with Docker build + `nginx -t` + functional curl tests.