### PR TITLE
fix: validate oauth2 session before redirecting authenticated users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,12 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-# Serve with Nginx
+# Serve with Nginx + njs for auth-aware redirect
 FROM nginx:alpine
+RUN apk add --no-cache nginx-module-njs
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY default.conf /etc/nginx/conf.d/default.conf
+COPY auth_redirect.js /etc/nginx/auth_redirect.js
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/auth_redirect.js
+++ b/auth_redirect.js
@@ -1,0 +1,39 @@
+// auth_redirect.js — njs script for auth-aware redirect
+//
+// Checks whether the user has a valid oauth2-proxy session by making
+// a subrequest to /oauth2/auth (proxied to oauth2-proxy in-cluster).
+//
+// Flow:
+//   1. If no _oauth2_proxy cookie → skip auth check, serve landing (fast path)
+//   2. If cookie present → subrequest to oauth2-proxy /oauth2/auth
+//      a. 2xx → session valid → 302 redirect to app.curiabots.com
+//      b. 401 → session invalid/expired → serve landing normally
+//      c. Error → serve landing (fail-open for anonymous content)
+
+async function checkAuthAndRedirect(r) {
+    // Fast path: no oauth2 cookie → serve landing directly.
+    // This avoids an extra network hop for the vast majority of visitors
+    // who have never authenticated.
+    let cookie = r.headersIn['Cookie'] || '';
+    if (!cookie.includes('_oauth2_proxy=')) {
+        r.internalRedirect('@landing');
+        return;
+    }
+
+    try {
+        let res = await r.subrequest('/oauth2/auth');
+        if (res.status >= 200 && res.status < 300) {
+            // Valid session → redirect to the authenticated app
+            r.return(302, 'https://app.curiabots.com');
+        } else {
+            // Invalid/expired session → serve landing
+            r.internalRedirect('@landing');
+        }
+    } catch (e) {
+        // Auth check failed (oauth2-proxy unreachable, etc.) → fail-open
+        // and serve the landing page rather than breaking the site.
+        r.internalRedirect('@landing');
+    }
+}
+
+export default { checkAuthAndRedirect };

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,78 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Cluster DNS for resolving k8s service names.
+    # "valid=30s" caches DNS results for 30 s so we don't hammer kube-dns
+    # on every request, while still picking up endpoint changes quickly.
+    resolver 10.43.0.10 valid=30s;
+
+    # Security headers (repeated in every location block because nginx
+    # does NOT inherit add_header directives into child blocks)
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self';" always;
+
+    # ── Auth-aware redirect ──────────────────────────────────────────
+    # Uses njs (auth_redirect.js) to check if the user has a valid
+    # oauth2-proxy session. The script:
+    #   1. No _oauth2_proxy cookie → serve landing (zero-latency fast path)
+    #   2. Cookie present → subrequest to oauth2-proxy /oauth2/auth
+    #      • 2xx → valid session → 302 redirect to app.curiabots.com
+    #      • 401 → expired/invalid → serve landing normally
+    #      • Error → fail-open, serve landing
+    #
+    # This replaces the previous cookie-existence check which couldn't
+    # distinguish valid sessions from stale cookies after logout.
+
+    # HTML page requests: auth check via njs
+    location / {
+        js_content auth_redirect.checkAuthAndRedirect;
+    }
+
+    # Serve the landing page (used by njs internalRedirect)
+    location @landing {
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self';" always;
+        try_files $uri $uri/ $uri/index.html =404;
+    }
+
+    # Internal subrequest to oauth2-proxy for session validation.
+    # Called by njs; only forwards cookies so oauth2-proxy can check
+    # the session. Response body is discarded — only status matters.
+    # Tight timeouts ensure we fail-open quickly if oauth2-proxy is down.
+    location = /oauth2/auth {
+        internal;
+        set $oauth2_upstream http://oauth2-proxy.overmind-platform.svc.cluster.local:4180;
+        proxy_pass $oauth2_upstream/oauth2/auth;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Cookie $http_cookie;
+        proxy_connect_timeout 2s;
+        proxy_read_timeout 2s;
+    }
+
+    # Cache static assets aggressively.
+    # No auth check here — assets don't need session validation and
+    # this avoids an extra subrequest on every .js/.css/.png load.
+    location ~* \.(?:js|css|png|jpg|jpeg|gif|ico|svg|woff2?|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self';" always;
+        try_files $uri =404;
+    }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,40 +1,31 @@
-server {
-    listen 80;
-    server_name _;
-    root /usr/share/nginx/html;
-    index index.html;
+# Main nginx configuration — loads the njs module required for
+# auth-aware redirect logic in auth_redirect.js.
+load_module modules/ngx_http_js_module.so;
 
-    # Security headers (repeated in every location block because nginx
-    # does NOT inherit add_header directives into child blocks)
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self';" always;
+user  nginx;
+worker_processes  auto;
 
-    # Redirect authenticated users to the app.
-    # The _oauth2_proxy cookie is set on .curiabots.com by oauth2-proxy,
-    # so it is sent to curiabots.com as well. If present, the user has
-    # (or recently had) an active session — redirect them to the app
-    # where oauth2-proxy will validate the session properly.
-    if ($cookie__oauth2_proxy) {
-        return 302 https://app.curiabots.com;
-    }
+error_log  /var/log/nginx/error.log notice;
+pid        /run/nginx.pid;
 
-    # SSG — serve pre-built static files (no SPA fallback needed)
-    location / {
-        try_files $uri $uri/ $uri/index.html =404;
-    }
+events {
+    worker_connections  1024;
+}
 
-    # Cache static assets aggressively
-    location ~* \.(?:js|css|png|jpg|jpeg|gif|ico|svg|woff2?|ttf|eot)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self';" always;
-        try_files $uri =404;
-    }
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    js_import auth_redirect from /etc/nginx/auth_redirect.js;
+
+    include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## Summary

Fixes the auth redirect that was merged in #4. The cookie-existence check (`if ($cookie__oauth2_proxy)`) doesn't work correctly because:

- The `_oauth2_proxy` cookie is `HttpOnly` — the app cannot delete it on logout
- The cookie persists in the browser after the user logs out (the app only clears its own JWT from `localStorage`)
- Result: **all users with a stale cookie get redirected forever**, even after logout

## Solution

Replace the naive cookie check with **actual session validation** using nginx njs (JavaScript scripting module):

1. **`auth_redirect.js`** — njs script that:
   - Fast path: if no `_oauth2_proxy` cookie → serve landing immediately (no extra latency for anonymous visitors)
   - Cookie present → subrequest to `oauth2-proxy /oauth2/auth` inside the cluster
   - `202` response → session valid → `302` redirect to `app.curiabots.com`
   - `401` response → session expired/invalid → serve landing normally
   - Network error → fail-open, serve landing (site never breaks)

2. **`nginx.conf`** — new main config that loads `ngx_http_js_module`

3. **`default.conf`** — server block config (renamed from old `nginx.conf`) with njs handler, `@landing` named location, and internal `/oauth2/auth` proxy to oauth2-proxy with 2s timeout

4. **`Dockerfile`** — adds `nginx-module-njs` package

## Why njs instead of nginx auth_request?

nginx's `auth_request` module has a fundamental limitation: when the subrequest returns 2xx (authenticated), the request continues normally — but there's no way to return a 302 redirect at that point. `return` runs in the rewrite phase (before auth_request) and `if` with `auth_request_set` variables doesn't work because variables are set after the rewrite phase. The njs approach gives us full control over the response.

## Testing

Verified locally with Docker integration test (mock oauth2-proxy + actual landing build):

| Scenario | Cookie | oauth2-proxy response | Result |
|---|---|---|---|
| Anonymous visitor | None | N/A (skipped) | 200 — Landing page |
| Authenticated user | Valid session | 202 | 302 → app.curiabots.com |
| Logged-out user (stale cookie) | Expired session | 401 | 200 — Landing page |
| Subpath `/es/` no cookie | None | N/A (skipped) | 200 — Landing ES |

Closes the redirect issue reported after #4 was deployed.