### PR TITLE
ci: migrate workflow to self-hosted runner

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 15
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Migrate GitHub Actions workflow to use the org-level self-hosted runner instead of GitHub-hosted `ubuntu-latest` runners, eliminating billable minutes.

Closes overmind-swarm/dev#138

## Changes

| File | Change |
|------|--------|
| `.github/workflows/*.yml` | Change `runs-on` to `[self-hosted, linux, x64]` |

## Test plan

- [ ] Workflow runs successfully on self-hosted runner after runner VPS is provisioned
- [ ] Build/deploy completes without errors

Part of overmind-swarm/dev#124 (self-hosted GitHub Actions runner)
Depends on: overmind-swarm/terraform#10, overmind-swarm/ansible#51