### PR TITLE
fix(ci): replace nc with bash /dev/tcp for port-forward health check

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -104,11 +104,11 @@ jobs:
           kubectl port-forward -n ${{ env.REGISTRY_NAMESPACE }} ${{ env.REGISTRY_SVC }} ${{ env.LOCAL_PORT }}:5000 &
           PF_PID=$!
           for i in $(seq 1 30); do
-            nc -z localhost ${{ env.LOCAL_PORT }} && break
+            (echo > /dev/tcp/localhost/${{ env.LOCAL_PORT }}) 2>/dev/null && break
             echo "Waiting for port-forward... ($i/30)"
             sleep 1
           done
-          nc -z localhost ${{ env.LOCAL_PORT }} || { echo "Port-forward failed to start"; kill $PF_PID 2>/dev/null; exit 1; }
+          (echo > /dev/tcp/localhost/${{ env.LOCAL_PORT }}) 2>/dev/null || { echo "Port-forward failed to start"; kill $PF_PID 2>/dev/null; exit 1; }
           docker push localhost:${{ env.LOCAL_PORT }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.new_version }}
           kill $PF_PID 2>/dev/null
 


### PR DESCRIPTION
## Summary

Replace `nc -z` (netcat) with bash built-in `/dev/tcp` for port-forward health checks. The self-hosted runner Docker image (`myoung34/github-runner:2.333.1`) does not include netcat, causing all workflows with `kubectl port-forward` to fail with `nc: command not found`.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/*.yml` | `nc -z localhost $PORT` → `(echo > /dev/tcp/localhost/$PORT) 2>/dev/null` |

## Test plan

- [ ] Workflow runs successfully on self-hosted runner
- [ ] Port-forward health check detects readiness correctly
- [ ] No regression on push-to-registry step