### PR TITLE
fix(deploy): update image refs from old K8s registry to VPS

### DIFF
--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -28,5 +28,5 @@ patches:
                       topologyKey: kubernetes.io/hostname
             containers:
               - name: landing
-                image: registry.overmind-platform.svc:5000/landing:0.3.3
+                image: 10.0.0.5:5050/landing:0.3.3
                 imagePullPolicy: Always


### PR DESCRIPTION
## Summary

Update deploy kustomization image references from `registry.overmind-platform.svc:5000` to `10.0.0.5:5050` so CI `sed` replacements work correctly with the VPS-hosted registry.

Part of overmind-swarm/dev#146.

## Changes

| File | Change |
|------|--------|
| `deploy/overlays/prod/kustomization.yaml` | `registry.overmind-platform.svc:5000/landing` → `10.0.0.5:5050/landing` |

## Test plan

- [ ] CI pipeline builds, pushes to VPS registry, and deploys successfully